### PR TITLE
fix: support MacOS/Windows in non-headless mode.

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -24,12 +24,12 @@ var (
 // New creates a context with an undetected Chrome executor.
 func New(config Config) (context.Context, context.CancelFunc, error) {
 	var (
-		opts               []chromedp.ExecAllocatorOption
-		isEmptyUserDataDir bool
+		opts    []chromedp.ExecAllocatorOption
+		tempDir bool
 	)
 
 	if config.UserDataDir == "" {
-		isEmptyUserDataDir = true
+		tempDir = true
 		config.UserDataDir = path.Join(os.TempDir(), DefaultUserDirPrefix+uuid.NewString())
 	}
 
@@ -74,7 +74,7 @@ func New(config Config) (context.Context, context.CancelFunc, error) {
 			slog.Error("failed to close Xvfb", err)
 		}
 
-		if isEmptyUserDataDir {
+		if tempDir {
 			_ = os.RemoveAll(config.UserDataDir) //nolint:errcheck
 		}
 	}
@@ -132,12 +132,16 @@ func headlessFlag(config Config) ([]chromedp.ExecAllocatorOption, func() error, 
 	cleanup := func() error { return nil }
 
 	if config.Headless {
-		var optx []chromedp.ExecAllocatorOption
-		var err error
+		var (
+			optx []chromedp.ExecAllocatorOption
+			err  error
+		)
+
 		optx, cleanup, err = headlessOpts()
 		if err != nil {
 			return nil, cleanup, err
 		}
+
 		opts = append(opts,
 			// chromedp.Flag("headless", true),
 			chromedp.Flag("window-size", "1920,1080"),

--- a/chrome.go
+++ b/chrome.go
@@ -32,8 +32,11 @@ func New(config Config) (context.Context, context.CancelFunc, error) {
 	if err != nil {
 		return nil, func() {}, err
 	}
-
-	opts = append(opts, localeFlag())
+	if config.Language == "" {
+		opts = append(opts, localeFlag())
+	} else {
+		opts = append(opts, chromedp.Flag("lang", config.Language))
+	}
 	opts = append(opts, supressWelcomeFlag()...)
 	opts = append(opts, logLevelFlag(config))
 	opts = append(opts, debuggerAddrFlag(config)...)

--- a/chrome.go
+++ b/chrome.go
@@ -23,20 +23,27 @@ var (
 
 // New creates a context with an undetected Chrome executor.
 func New(config Config) (context.Context, context.CancelFunc, error) {
-	var opts []chromedp.ExecAllocatorOption
-	isEmptyUserDataDir := (config.UserDataDir == "")
-	if isEmptyUserDataDir {
+	var (
+		opts               []chromedp.ExecAllocatorOption
+		isEmptyUserDataDir bool
+	)
+
+	if config.UserDataDir == "" {
+		isEmptyUserDataDir = true
 		config.UserDataDir = path.Join(os.TempDir(), DefaultUserDirPrefix+uuid.NewString())
 	}
+
 	headlessOpts, closeFrameBuffer, err := headlessFlag(config)
 	if err != nil {
 		return nil, func() {}, err
 	}
+
 	if config.Language == "" {
 		opts = append(opts, localeFlag())
 	} else {
 		opts = append(opts, chromedp.Flag("lang", config.Language))
 	}
+
 	opts = append(opts, supressWelcomeFlag()...)
 	opts = append(opts, logLevelFlag(config))
 	opts = append(opts, debuggerAddrFlag(config)...)

--- a/chrome_darwin.go
+++ b/chrome_darwin.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+// Package chromedpundetected provides a chromedp context with an undetected
+// Chrome browser.
+package chromedpundetected
+
+import (
+	"errors"
+
+	"github.com/chromedp/chromedp"
+)
+
+func headlessOpts() (opts []chromedp.ExecAllocatorOption, cleanup func() error, err error) {
+	return nil, nil, errors.New("headless mode not supported in darwin")
+}

--- a/chrome_unix.go
+++ b/chrome_unix.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+// Package chromedpundetected provides a chromedp context with an undetected
+// Chrome browser.
+package chromedpundetected
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/chromedp/chromedp"
+)
+
+func headlessOpts() (opts []chromedp.ExecAllocatorOption, cleanup func() error, err error) {
+	// Create virtual display
+	frameBuffer, err := newFrameBuffer("1920x1080x24")
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup = frameBuffer.Stop
+	opt := chromedp.ModifyCmdFunc(func(cmd *exec.Cmd) {
+		cmd.Env = append(cmd.Env, "DISPLAY=:"+frameBuffer.Display)
+		cmd.Env = append(cmd.Env, "XAUTHORITY="+frameBuffer.AuthPath)
+
+		// Default modify command per chromedp
+		if _, ok := os.LookupEnv("LAMBDA_TASK_ROOT"); ok {
+			// do nothing on AWS Lambda
+			return
+		}
+
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = new(syscall.SysProcAttr)
+		}
+
+		// When the parent process dies (Go), kill the child as well.
+		cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+	})
+	return []chromedp.ExecAllocatorOption{opt}, cleanup, nil
+}

--- a/chrome_windows.go
+++ b/chrome_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+// Package chromedpundetected provides a chromedp context with an undetected
+// Chrome browser.
+package chromedpundetected
+
+import (
+	"errors"
+
+	"github.com/chromedp/chromedp"
+)
+
+func headlessOpts() (opts []chromedp.ExecAllocatorOption, cleanup func() error, err error) {
+	return nil, nil, errors.New("headless mode not supported in windows")
+}

--- a/config.go
+++ b/config.go
@@ -58,6 +58,10 @@ type Config struct {
 	// It will NOT use the '--headless' option, rather it will use a virtual display.
 	// Requires Xvfb to be installed, only available on Linux.
 	Headless bool `json:"headless" yaml:"headless"`
+
+	// language to be used otherwise system/OS defaults are used
+	// https://developer.chrome.com/docs/webstore/i18n/#localeTable
+	Language string
 }
 
 // NewConfig creates a new config object with defaults.

--- a/display_linux.go
+++ b/display_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package chromedpundetected
 
 import (


### PR DESCRIPTION
This PR fixes the compilation issue on MacOS and potentially Windows with minimal invasion. It simply moves the ModifyCmdFunc option into a tag specific build(windows,linux,macos) file.
It does not provide support for MacOS and Windows in headless mode but it fails gracefully. 
Further support for headless mode on Windows and MacOS can be added in the stub files (i.e. chrome_darwin).