### PR TITLE
fix: add OS check to pdeathsig

### DIFF
--- a/chrome.go
+++ b/chrome.go
@@ -4,7 +4,6 @@ package chromedpundetected
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -129,7 +128,6 @@ func headlessFlag(config Config) ([]chromedp.ExecAllocatorOption, func() error, 
 
 	if config.Headless {
 		// Create virtual display
-		// frameBuffer, err := newFrameBuffer("1920x1080x24")
 		frameBuffer, err := newFrameBuffer("1280x1024x16")
 		if err != nil {
 			return nil, nil, err
@@ -137,9 +135,7 @@ func headlessFlag(config Config) ([]chromedp.ExecAllocatorOption, func() error, 
 
 		cleanup = frameBuffer.Stop
 
-		fmt.Println("Yes, debuggin...")
 		opts = append(opts,
-			// chromedp.Flag("headless", true),
 			// chromedp.Flag("window-size", "1920,1080"),
 			// chromedp.Flag("start-maximized", true),
 			chromedp.Flag("no-sandbox", true),

--- a/display.go
+++ b/display.go
@@ -67,8 +67,8 @@ func newFrameBuffer(screenSize string) (*frameBuffer, error) { //nolint:funlen
 			return nil, fmt.Errorf("invalid screen size: expected 'WxH[xD]', got %q", screenSize)
 		}
 
-		arguments = append(arguments, "-screen", ":3", screenSize)
 		// arguments = append(arguments, "-screen", "0", screenSize)
+		arguments = append(arguments, "-screen", ":3", screenSize)
 	}
 
 	xvfb := exec.Command("Xvfb", arguments...)
@@ -104,7 +104,7 @@ func newFrameBuffer(screenSize string) (*frameBuffer, error) { //nolint:funlen
 		ch <- resp{s, err}
 	}()
 
-	var display string
+	// var display string
 	// select {
 	// case resp := <-ch:
 	// 	if resp.err != nil {
@@ -120,7 +120,7 @@ func newFrameBuffer(screenSize string) (*frameBuffer, error) { //nolint:funlen
 	// 	return nil, errors.New("timeout waiting for Xvfb")
 	// }
 
-	display = "3"
+	display := "3"
 	xauth := exec.Command("xauth", "generate", ":"+display, ".", "trusted") //nolint:gosec
 	xauth.Env = append(xauth.Env, "XAUTHORITY="+authPath)
 	// Make make this conditional?


### PR DESCRIPTION
Fix Windows/ Mac support

On linux with `pdeathsig` it will automatically kill the child processes, that is currently not implemented on mac/linux